### PR TITLE
Fix a warning that can occur during global destruction

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 Revision history for Perl module Parallel::Scoreboard
+ - fixed a warning that could occur during global destruction when an attribute in the scoreboard object was destroyed before the object itself (Dave Rolsky)
 
 0.05 2014-04-09
  - when cleaning up obsolete scoreboard files, ignore errors when another process cleaned up the file at the same time (Karen Etheridge)

--- a/lib/Parallel/Scoreboard.pm
+++ b/lib/Parallel/Scoreboard.pm
@@ -40,8 +40,11 @@ sub DESTROY {
     # if file is open, close and unlink
     if ($self->{fh}) {
         close $self->{fh};
-        my $fn = $self->_build_filename();
-        unlink $fn;
+        # during global destruction we may already have lost this
+        if ($self->{base_dir}) {
+            my $fn = $self->_build_filename();
+            unlink $fn;
+        }
     }
 }
 

--- a/t/01destroy.t
+++ b/t/01destroy.t
@@ -1,0 +1,38 @@
+use strict;
+use warnings;
+
+use File::Temp qw(tempdir);
+
+use Test::More;
+
+my $has_test_warn = do {
+    local $@;
+    eval 'use Test::Warn';
+    1;
+};
+
+if ($has_test_warn) {
+    plan tests => 2;
+}
+else {
+    plan skip_all => 'These tests require Test::Warn';
+}
+
+use_ok('Parallel::Scoreboard');
+
+# create temporary directory
+my $base_dir = tempdir(CLEANUP => 1);
+
+# instantiate
+my $sb = Parallel::Scoreboard->new(
+    base_dir => $base_dir,
+);
+
+$sb->update('X');
+
+# simulate global destruction by deleting this attribute before DESTROY is
+# called
+delete $sb->{base_dir};
+
+warning_is(sub { undef $sb }, undef,
+    'no warnings when object is destroyed and base_dir is undef');


### PR DESCRIPTION
Use of uninitialized value in concatenation (.) or string at /opt/perl5.16.3/lib/site_perl/5.16.3/Parallel/Scoreboard.pm line 145 during global destruction.
