### PR TITLE
skip .tmp files in _for_all to avoid race with update() (fixes #12)

### DIFF
--- a/lib/Parallel/Scoreboard.pm
+++ b/lib/Parallel/Scoreboard.pm
@@ -117,8 +117,9 @@ sub _for_all {
     my ($self, $cb) = @_;
     my @files = glob "$self->{base_dir}/status_*";
     for my $fn (@files) {
-        # obtain id from filename (or else ignore)
-        $fn =~ m|/status_(.*)$|
+        # obtain id from filename (or else ignore);
+        # skip .tmp to avoid racing with update()
+        $fn =~ m|/status_(.*)(?<!\.tmp)$|
             or next;
         my $id = $1;
         # ignore files removed after glob but before open

--- a/t/02read_all_ignores_tmp.t
+++ b/t/02read_all_ignores_tmp.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+
+use File::Temp qw(tempdir);
+use Test::More tests => 3;
+
+use_ok('Parallel::Scoreboard');
+
+my $base_dir = tempdir(CLEANUP => 1);
+
+my $sb = Parallel::Scoreboard->new(
+    base_dir => $base_dir,
+);
+
+# simulate a .tmp file left by another worker (id != $$)
+my $tmp_path = "$base_dir/status_99999.tmp";
+open my $tmp_fh, '>', $tmp_path or die "failed to create tmp fixture: $!";
+
+$sb->update('me manager');
+
+my $stats = $sb->read_all();
+
+ok(-e $tmp_path, 'read_all does not unlink .tmp files');
+is_deeply($stats, {$$ => 'me manager'}, 'read_all only returns real status files');


### PR DESCRIPTION
## Summary

Fixes #12. `_for_all` races with another process's `update()` and can unlink
its in-flight `status_X.tmp` before the rename, causing that `update()` to die
with:

    failed to rename file: .../status_X.tmp to .../status_X: :No such file or directory

See #12 for the detailed race scenario.

## Fix

Make `_for_all` ignore `.tmp`.

## Note

`cleanup()` no longer removes `.tmp` files. Is `cleanup()` actually used
anywhere? Let me know if this is a problem.

## Test results (local)


```console
root@2526009a8051:/workspaces/p5-Parallel-Scoreboard# perl -v | head -2

This is perl 5, version 42, subversion 1 (v5.42.1) built for aarch64-linux-gnu

root@2526009a8051:/workspaces/p5-Parallel-Scoreboard# make test
PERL_DL_NONLAZY=1 "/usr/local/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'inc', 'blib/lib', 'blib/arch')" t/*.t
t/00base.t .................. ok     
t/01destroy.t ............... ok   
t/02read_all_ignores_tmp.t .. ok   
All tests successful.
Files=3, Tests=20,  3 wallclock secs ( 0.01 usr  0.00 sys +  0.07 cusr  0.02 csys =  0.10 CPU)
Result: PASS
```
